### PR TITLE
Get latest builds

### DIFF
--- a/.github/ops-bot.yml
+++ b/.github/ops-bot.yml
@@ -1,5 +1,0 @@
-# This file controls which features from the `ops-bot` repository below are enabled.
-# - https://github.com/rapidsai/ops-bot
-
-copy_prs: true
-

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -1,11 +1,10 @@
 name: Build RAPIDS pip wheel CI images
 
 on:
-  pull_request:
-
   push:
     branches:
       - "main"
+	  - "pull-request/[0-9]+"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -1,6 +1,8 @@
 name: Build RAPIDS pip wheel CI images
 
 on:
+  pull-request:
+
   push:
     branches:
       - "main"

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -24,5 +24,5 @@ jobs:
     secrets: inherit
     with:
       matrix_script: "./ci/compute-manylinux-matrix.sh"
-      push: true
+      push: false
       build_type: branch

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -1,7 +1,7 @@
 name: Build RAPIDS pip wheel CI images
 
 on:
-  pull-request:
+  pull_request:
 
   push:
     branches:

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "main"
-	  - "pull-request/[0-9]+"
+      - "pull-request/[0-9]+"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -12,13 +12,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  #cibw-containers:
-  #  uses: ./.github/workflows/docker-multiarch-native.yml
-  #  secrets: inherit
-  #  with:
-  #    matrix_script: "./ci/compute-cibw-matrix.sh"
-  #    push: true
-  #    build_type: branch
+  cibw-containers:
+    uses: ./.github/workflows/docker-multiarch-native.yml
+    secrets: inherit
+    with:
+      matrix_script: "./ci/compute-cibw-matrix.sh"
+      push: true
+      build_type: branch
   manylinux-containers:
     uses: ./.github/workflows/docker-multiarch-native.yml
     secrets: inherit

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "pull-request/[0-9]+"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -24,5 +24,5 @@ jobs:
     secrets: inherit
     with:
       matrix_script: "./ci/compute-manylinux-matrix.sh"
-      push: false
+      push: true
       build_type: branch

--- a/.github/workflows/docker-multiarch-native.yml
+++ b/.github/workflows/docker-multiarch-native.yml
@@ -160,5 +160,5 @@ jobs:
           set -x
           for manifest in ${{ steps.manifests-create.outputs.MANIFESTS_TO_PUSH }}; do
             echo "copying multiarch manifest with skopeo: ${manifest}"
-            skopeo copy --multi-arch=all --src-tls-verify=false "docker://localhost:5000/${manifest}" "docker://docker.io/${manifest}"
+            skopeo copy --multi-arch=all --insecure-policy --src-tls-verify=false "docker://localhost:5000/${manifest}" "docker://docker.io/${manifest}"
           done

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,6 @@
 set -eou pipefail
 set -x
 
-curl --verbose https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm --output ./dummy && echo $? && ls -latrh dummy
-
 image_to_build="${BUILD_IMAGE:-""}"
 
 if [[ "${image_to_build}" == "" ]]; then


### PR DESCRIPTION
Container builds have been outdated for a while due to various issues. This PR fixes enough of them to get builds working again. There appear to also be some connectivity issues that were previously showing up in CI on main but aren't blocking builds on this PR. After merging we will see if they reappear.