### PR TITLE
Update UCX to 1.14.0

### DIFF
--- a/manylinux_v2_centos/Dockerfile
+++ b/manylinux_v2_centos/Dockerfile
@@ -32,10 +32,12 @@ RUN curl -o /tmp/sccache.tar.gz \
         chmod +x /usr/bin/sccache
 
 # Install ucx
-ARG UCX_VERSION=1.13.0
+ARG UCX_VERSION=1.14.0
 RUN mkdir -p /ucx-src && pushd /ucx-src &&\
     git clone https://github.com/openucx/ucx -b v${UCX_VERSION} ucx-git-repo &&\
     cd ucx-git-repo && \
+    curl https://raw.githubusercontent.com/pentschev/ucx-split-feedstock/cuda-12-nvidia-channel/recipe/cuda12.patch > cuda12.patch && \
+    git apply cuda12.patch && \
     ./autogen.sh && \
     ./contrib/configure-release \
        --prefix=/usr               \

--- a/manylinux_v2_centos/Dockerfile
+++ b/manylinux_v2_centos/Dockerfile
@@ -31,13 +31,13 @@ RUN curl -o /tmp/sccache.tar.gz \
         mv "/tmp/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl/sccache" /usr/bin/sccache && \
         chmod +x /usr/bin/sccache
 
-# Install ucx
+# Install ucx and apply patch for CUDA 12
+COPY cuda12.patch /ucx_cuda12_patch/cuda12.patch
 ARG UCX_VERSION=1.14.0
 RUN mkdir -p /ucx-src && pushd /ucx-src &&\
     git clone https://github.com/openucx/ucx -b v${UCX_VERSION} ucx-git-repo &&\
     cd ucx-git-repo && \
-    curl https://raw.githubusercontent.com/pentschev/ucx-split-feedstock/cuda-12-nvidia-channel/recipe/cuda12.patch > cuda12.patch && \
-    git apply cuda12.patch && \
+    git apply /ucx_cuda12_patch/cuda12.patch && \
     ./autogen.sh && \
     ./contrib/configure-release \
        --prefix=/usr               \
@@ -52,7 +52,8 @@ RUN mkdir -p /ucx-src && pushd /ucx-src &&\
     CPPFLAGS=-I/usr/local/cuda/include make -j && \
     make install && \
     popd && \
-    rm -rf /ucx-src/
+    rm -rf /ucx-src/ && \
+    rm -rf /ucx_cuda12_patch/
 
 # for pyenv
 ARG PY39_VERSION="3.9.16"

--- a/manylinux_v2_centos/cuda12.patch
+++ b/manylinux_v2_centos/cuda12.patch
@@ -1,0 +1,39 @@
+From eadc411798dee36d337a29402744f1374c5bc62d Mon Sep 17 00:00:00 2001
+From: "Pasha (Pavel) Shamis" <pasharesearch@gmail.com>
+Date: Mon, 12 Dec 2022 08:27:33 -0600
+Subject: [PATCH] CUDA: make cuGetProcAddress to work with cuda 12
+
+---
+ src/uct/cuda/base/cuda_md.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/uct/cuda/base/cuda_md.c b/src/uct/cuda/base/cuda_md.c
+index 99eeb41aa10..2e940288f48 100644
+--- a/src/uct/cuda/base/cuda_md.c
++++ b/src/uct/cuda/base/cuda_md.c
+@@ -231,6 +231,17 @@ static int uct_cuda_copy_get_dmabuf_fd(const ucs_memory_info_t *addr_mem_info)
+     /* Get fxn ptr for cuMemGetHandleForAddressRange in case installed libcuda
+      * does not have the definition for it even though 11.7 header includes the
+      * declaration and avoid link error */
++#if CUDA_VERSION >= 12000
++    CUdriverProcAddressQueryResult proc_addr_res;
++    cu_err = cuGetProcAddress("cuMemGetHandleForAddressRange",
++                              (void**)&get_handle_func, 12000,
++                              CU_GET_PROC_ADDRESS_DEFAULT, &proc_addr_res);
++    if ((cu_err != CUDA_SUCCESS) ||
++        (proc_addr_res != CU_GET_PROC_ADDRESS_SUCCESS)) {
++        ucs_debug("cuMemGetHandleForAddressRange not found");
++        return UCT_DMABUF_FD_INVALID;
++    }
++#else
+     cu_err = cuGetProcAddress("cuMemGetHandleForAddressRange",
+                               (void**)&get_handle_func, 11070,
+                               CU_GET_PROC_ADDRESS_DEFAULT);
+@@ -238,6 +249,7 @@ static int uct_cuda_copy_get_dmabuf_fd(const ucs_memory_info_t *addr_mem_info)
+         ucs_debug("cuMemGetHandleForAddressRange not found");
+         return UCT_DMABUF_FD_INVALID;
+     }
++#endif
+ 
+     cu_err = get_handle_func((void*)&fd, (uintptr_t)addr_mem_info->base_address,
+                              addr_mem_info->alloc_length,

--- a/manylinux_v2_ubuntu/Dockerfile
+++ b/manylinux_v2_ubuntu/Dockerfile
@@ -23,10 +23,12 @@ RUN curl -o /tmp/sccache.tar.gz \
         chmod +x /usr/bin/sccache
 
 # Install ucx
-ARG UCX_VERSION=1.13.0
+ARG UCX_VERSION=1.14.0
 RUN mkdir -p /ucx-src && cd /ucx-src &&\
     git clone https://github.com/openucx/ucx -b v${UCX_VERSION} ucx-git-repo &&\
     cd ucx-git-repo && \
+    curl https://raw.githubusercontent.com/pentschev/ucx-split-feedstock/cuda-12-nvidia-channel/recipe/cuda12.patch > cuda12.patch && \
+    git apply cuda12.patch && \
     ./autogen.sh && \
     ./contrib/configure-release \
        --prefix=/usr               \

--- a/manylinux_v2_ubuntu/Dockerfile
+++ b/manylinux_v2_ubuntu/Dockerfile
@@ -22,13 +22,13 @@ RUN curl -o /tmp/sccache.tar.gz \
         mv "/tmp/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl/sccache" /usr/bin/sccache && \
         chmod +x /usr/bin/sccache
 
-# Install ucx
+# Install ucx and apply patch for CUDA 12
+COPY cuda12.patch /ucx_cuda12_patch/cuda12.patch
 ARG UCX_VERSION=1.14.0
 RUN mkdir -p /ucx-src && cd /ucx-src &&\
     git clone https://github.com/openucx/ucx -b v${UCX_VERSION} ucx-git-repo &&\
     cd ucx-git-repo && \
-    curl https://raw.githubusercontent.com/pentschev/ucx-split-feedstock/cuda-12-nvidia-channel/recipe/cuda12.patch > cuda12.patch && \
-    git apply cuda12.patch && \
+    git apply /ucx_cuda12_patch/cuda12.patch && \
     ./autogen.sh && \
     ./contrib/configure-release \
        --prefix=/usr               \
@@ -43,7 +43,8 @@ RUN mkdir -p /ucx-src && cd /ucx-src &&\
     CPPFLAGS=-I/usr/local/cuda/include make -j && \
     make install && \
     cd / && \
-    rm -rf /ucx-src/
+    rm -rf /ucx-src/ && \
+    rm -rf /ucx_cuda12_patch/
 
 # for pyenv
 ARG PY39_VERSION="3.9.16"

--- a/manylinux_v2_ubuntu/cuda12.patch
+++ b/manylinux_v2_ubuntu/cuda12.patch
@@ -1,0 +1,39 @@
+From eadc411798dee36d337a29402744f1374c5bc62d Mon Sep 17 00:00:00 2001
+From: "Pasha (Pavel) Shamis" <pasharesearch@gmail.com>
+Date: Mon, 12 Dec 2022 08:27:33 -0600
+Subject: [PATCH] CUDA: make cuGetProcAddress to work with cuda 12
+
+---
+ src/uct/cuda/base/cuda_md.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/uct/cuda/base/cuda_md.c b/src/uct/cuda/base/cuda_md.c
+index 99eeb41aa10..2e940288f48 100644
+--- a/src/uct/cuda/base/cuda_md.c
++++ b/src/uct/cuda/base/cuda_md.c
+@@ -231,6 +231,17 @@ static int uct_cuda_copy_get_dmabuf_fd(const ucs_memory_info_t *addr_mem_info)
+     /* Get fxn ptr for cuMemGetHandleForAddressRange in case installed libcuda
+      * does not have the definition for it even though 11.7 header includes the
+      * declaration and avoid link error */
++#if CUDA_VERSION >= 12000
++    CUdriverProcAddressQueryResult proc_addr_res;
++    cu_err = cuGetProcAddress("cuMemGetHandleForAddressRange",
++                              (void**)&get_handle_func, 12000,
++                              CU_GET_PROC_ADDRESS_DEFAULT, &proc_addr_res);
++    if ((cu_err != CUDA_SUCCESS) ||
++        (proc_addr_res != CU_GET_PROC_ADDRESS_SUCCESS)) {
++        ucs_debug("cuMemGetHandleForAddressRange not found");
++        return UCT_DMABUF_FD_INVALID;
++    }
++#else
+     cu_err = cuGetProcAddress("cuMemGetHandleForAddressRange",
+                               (void**)&get_handle_func, 11070,
+                               CU_GET_PROC_ADDRESS_DEFAULT);
+@@ -238,6 +249,7 @@ static int uct_cuda_copy_get_dmabuf_fd(const ucs_memory_info_t *addr_mem_info)
+         ucs_debug("cuMemGetHandleForAddressRange not found");
+         return UCT_DMABUF_FD_INVALID;
+     }
++#endif
+ 
+     cu_err = get_handle_func((void*)&fd, (uintptr_t)addr_mem_info->base_address,
+                              addr_mem_info->alloc_length,


### PR DESCRIPTION
This PR also applies [this patch](https://github.com/pentschev/ucx-split-feedstock/blob/cuda-12-nvidia-channel/recipe/cuda12.patch) to make UCX 1.14.0 compatible with CUDA 12