### PR TITLE
Adds AUDITWHEEL_* env vars to Dockerfiles

### DIFF
--- a/manylinux_v2_centos/Dockerfile
+++ b/manylinux_v2_centos/Dockerfile
@@ -31,6 +31,10 @@ RUN curl -o /tmp/sccache.tar.gz \
         mv "/tmp/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl/sccache" /usr/bin/sccache && \
         chmod +x /usr/bin/sccache
 
+# Set AUDITWHEEL_*
+ARG POLICY=manylinux_2_17
+ENV AUDITWHEEL_POLICY=${POLICY} AUDITWHEEL_ARCH=${ARCH} AUDITWHEEL_PLAT=${POLICY}_${ARCH}
+
 # Install ucx
 ARG UCX_VERSION=1.14.1
 RUN mkdir -p /ucx-src && pushd /ucx-src &&\

--- a/manylinux_v2_ubuntu/Dockerfile
+++ b/manylinux_v2_ubuntu/Dockerfile
@@ -22,6 +22,10 @@ RUN curl -o /tmp/sccache.tar.gz \
         mv "/tmp/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl/sccache" /usr/bin/sccache && \
         chmod +x /usr/bin/sccache
 
+# Set AUDITWHEEL_*
+ARG POLICY=manylinux_2_31
+ENV AUDITWHEEL_POLICY=${POLICY} AUDITWHEEL_ARCH=${ARCH} AUDITWHEEL_PLAT=${POLICY}_${ARCH}
+
 # Install ucx
 ARG UCX_VERSION=1.14.1
 RUN mkdir -p /ucx-src && cd /ucx-src &&\


### PR DESCRIPTION
closes https://github.com/rapidsai/cibuildwheel-imgs/issues/16

Adds `AUDITWHEEL_*` env vars based on the same setting [here](https://github.com/pypa/manylinux/blob/ccefaeb4f51335074f38a7da7b2e5450f6a9b71b/docker/Dockerfile#L17).  This allows `auditwheel` to recognize the platform type without requiring it be explicitly specified (as described [here](https://github.com/rapidsai/shared-action-workflows/issues/80)).