### PR TITLE
Fix Python 3.10 `PATH`

### DIFF
--- a/ciwheel/Dockerfile
+++ b/ciwheel/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p /citools-bin &&\
 RUN pyenv global ${PY39_VERSION} && python --version
 
 # add bin to path
-ENV PATH="/pyenv/versions/${PY39_VERSION}/bin/:$/pyenv/versions/${PY310_VERSION}/bin/:/citools-bin/:$PATH"
+ENV PATH="/pyenv/versions/${PY39_VERSION}/bin/:/pyenv/versions/${PY310_VERSION}/bin/:/citools-bin/:$PATH"
 
 # install docker-in-docker
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
The path for Python 3.10 has a `$` prefixed, so newly installed binaries are not found.

See: https://github.com/rapidsai/cugraph/actions/runs/5158657951/jobs/9293998296?pr=3629

<details><summary>Log showing the issue in the current docker image</summary>
<p>

```
 docker pull rapidsai/citestwheel:cuda-devel-12.0.1-ubuntu18.04
cuda-devel-12.0.1-ubuntu18.04: Pulling from rapidsai/citestwheel
0064b1b97ec0: Pull complete 
c0d27510239d: Pull complete 
4b96cc32b76f: Pull complete 
12eb26edb270: Pull complete 
456b49956d7c: Pull complete 
c0e66a1852b0: Pull complete 
f0915656122c: Pull complete 
7f10a1cc33db: Pull complete 
a0501e5f4012: Pull complete 
4862fc7cb9fe: Pull complete 
639a744ba0e8: Pull complete 
badcc218aa07: Pull complete 
88b1dab4d5c3: Pull complete 
7be8366013c8: Pull complete 
10217a77e969: Pull complete 
b7afc648d21d: Pull complete 
762d0079e71c: Pull complete 
e9312aaf1912: Pull complete 
fb26580cc1d5: Pull complete 
d70c1f2beffc: Pull complete 
8c6ca31c8630: Pull complete 
f12437ac8106: Pull complete 
858e2810c394: Pull complete 
425ef8da0cdb: Pull complete 
303ee9970641: Pull complete 
4e84d4d8a323: Pull complete 
Digest: sha256:aa895e1e8208fd76e9e5a72d9371e6b0967f6d34c8ea0c9fbdc1d52e66a110d0
Status: Downloaded newer image for rapidsai/citestwheel:cuda-devel-12.0.1-ubuntu18.04
docker.io/rapidsai/citestwheel:cuda-devel-12.0.1-ubuntu18.04
$ docker run -it --rm rapidsai/citestwheel:cuda-devel-12.0.1-ubuntu18.04
root@52933312c84d:/# eval "$(pyenv init -)"
root@52933312c84d:/# pyenv global 3.10.9
root@52933312c84d:/# python -m pip install pytest
Collecting pytest
  Downloading pytest-7.3.1-py3-none-any.whl (320 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 320.5/320.5 kB 4.9 MB/s eta 0:00:00
Collecting exceptiongroup>=1.0.0rc8
  Downloading exceptiongroup-1.1.1-py3-none-any.whl (14 kB)
Collecting pluggy<2.0,>=0.12
  Downloading pluggy-1.0.0-py2.py3-none-any.whl (13 kB)
Collecting packaging
  Using cached packaging-23.1-py3-none-any.whl (48 kB)
Collecting tomli>=1.0.0
  Using cached tomli-2.0.1-py3-none-any.whl (12 kB)
Collecting iniconfig
  Downloading iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
Installing collected packages: tomli, pluggy, packaging, iniconfig, exceptiongroup, pytest
Successfully installed exceptiongroup-1.1.1 iniconfig-2.0.0 packaging-23.1 pluggy-1.0.0 pytest-7.3.1 tomli-2.0.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

[notice] A new release of pip available: 22.3.1 -> 23.1.2
[notice] To update, run: pip install --upgrade pip
root@52933312c84d:/# which pytest
root@52933312c84d:/# ll /pyenv/versions/3.10.9/bin/pytest 
-rwxr-xr-x 1 root root 238 Jun  2 21:04 /pyenv/versions/3.10.9/bin/pytest*
root@52933312c84d:/# export PATH="$PATH:/pyenv/versions/3.10.9/bin"
root@52933312c84d:/# which pytest
/pyenv/versions/3.10.9/bin/pytest
```

</p>
</details> 