### PR TITLE
Install `awscli` at system level

### DIFF
--- a/ci-wheel/Dockerfile
+++ b/ci-wheel/Dockerfile
@@ -28,7 +28,7 @@ RUN case "${LINUX_VER}" in \
         && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9 \
       ;; \
     "centos"*) \
-        yum update -y && yum install -y epel-release wget gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel xz xz-devel libffi-devel curl git ncurses-devel numactl numactl-devel openssh-clients libcudnn8-devel zip blas-devel lapack-devel protobuf-compiler autoconf automake libtool centos-release-scl scl-utils cmake && yum clean all \
+        yum update --exclude=libnccl* -y && yum install -y epel-release wget gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel xz xz-devel libffi-devel curl git ncurses-devel numactl numactl-devel openssh-clients libcudnn8-devel zip blas-devel lapack-devel protobuf-compiler autoconf automake libtool centos-release-scl scl-utils cmake && yum clean all \
         && yum remove -y git && yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && yum install -y git jq devtoolset-11 && yum remove -y endpoint-repo \
         && echo -e ' \
         #!/bin/bash\n \

--- a/citestwheel/Dockerfile
+++ b/citestwheel/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
         wget curl git jq ssh \
         make build-essential libssl-dev zlib1g-dev \
         libbz2-dev libreadline-dev libsqlite3-dev wget \
-        curl llvm libncursesw5-dev xz-utils tk-dev \
+        curl llvm libncursesw5-dev xz-utils tk-dev unzip \
         libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 
 # Install pyenv
@@ -33,7 +33,13 @@ ENV PATH="/pyenv/versions/${PYTHON_VER}/bin/:$PATH"
 
 # Install the AWS CLI
 # Needed to download wheels for running tests
-RUN python3 -m pip install awscli
+# Install the AWS CLI
+RUN mkdir -p /aws_install && cd /aws_install && \
+    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
+    unzip awscli-bundle.zip && \
+    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
+    cd / && \
+    rm -rf /aws_install
 
 COPY citestwheel.sh /citestwheel.sh
 


### PR DESCRIPTION
`cuml` CI [broke](https://github.com/rapidsai/cuml/actions/runs/5420530289/jobs/9854798714) as a result of `awscli` and `sphinx` having conflicting dependency requirements on `docutils` version. This PR fixes it by installing `awscli` at the system level, and in general trying to keep the `pyenv` clean of packages that are not a RAPIDS package and its dependencies.