### PR TITLE
Update `push.yml` workflow branch

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,7 +3,7 @@ name: publish
 on:
   push:
     branches:
-      - "imgs-v2"
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR updates the `push.yml` workflow to trigger on pushes to `main` instead of `imgs-v2`, which has been deleted.