### PR TITLE
add repo values to matrix

### DIFF
--- a/ci/compute-mx.jq
+++ b/ci/compute-mx.jq
@@ -13,6 +13,30 @@ def compute_arch($x):
 def matches($entry; $exclude):
   all($exclude | to_entries | .[]; $entry[.key] == .value);
 
+def compute_tag_prefix($x):
+  if $build_type == "pull-request" then
+    $x.IMAGE_REPO + "-" + $pr_num + "-"
+  else
+    ""
+  end |
+  $x + {TAG_PREFIX: .};
+
+def compute_used_repo($x):
+  if $build_type == "pull-request" then
+    "staging"
+  else
+    $x.IMAGE_REPO
+  end |
+  $x + {USED_REPO: .};
+
+def compute_full_prefix($x):
+  if $build_type == "pull-request" then
+    "rapidsai/"+$x.USED_REPO+":"+$x.TAG_PREFIX
+  else
+    "rapidsai/" + $x.IMAGE_REPO + ":"
+  end |
+  $x + {FULL_PREFIX: .};
+
 # Checks the current entry to see if it matches any of the excludes.
 # If so, produce no output. Otherwise, output the entry.
 def filter_excludes($entry; $excludes):
@@ -31,6 +55,9 @@ def compute_mx($input):
     combinations |
     lists2dict($mx_keys; .) |
     filter_excludes(.; $excludes) |
-    compute_arch(.)
+    compute_arch(.) |
+    compute_tag_prefix(.) |
+    compute_used_repo(.) |
+    compute_full_prefix(.)
   ] |
   {include: .};

--- a/ci/compute-mx.sh
+++ b/ci/compute-mx.sh
@@ -2,4 +2,8 @@
 
 set -euo pipefail
 
-yq -o json axis.yaml | jq -c 'include "ci/compute-mx"; compute_mx(.)'
+PR_NUM=${PR_NUM:-""}
+BUILD_TYPE=${BUILD_TYPE:-""}
+
+yq -o json axis.yaml | jq -c 'include "ci/compute-mx"; compute_mx(.)' --arg pr_num "${PR_NUM}" --arg build_type "${BUILD_TYPE}"
+


### PR DESCRIPTION
This updates the matrix data structure computed by the `compute-mx.jq` script to include values that will be needed for the new PR workflows set up in #33 