### PR TITLE
Install dfg into build container

### DIFF
--- a/ci-wheel/Dockerfile
+++ b/ci-wheel/Dockerfile
@@ -125,7 +125,7 @@ RUN case "${LINUX_VER}" in \
       ;; \
   esac
 
-RUN pyenv global ${PYTHON_VER} && python -m pip install auditwheel patchelf twine && pyenv rehash
+RUN pyenv global ${PYTHON_VER} && python -m pip install auditwheel patchelf twine rapids-dependency-file-generator && pyenv rehash
 
 # Install latest gha-tools
 RUN wget https://github.com/rapidsai/gha-tools/releases/latest/download/tools.tar.gz -O - | tar -xz -C /usr/local/bin


### PR DESCRIPTION
Switching to wheel builds without isolation requires preinstalling build dependencies, for which we need dfg to generate requirements.txt files.